### PR TITLE
Navigation: check if folder has content

### DIFF
--- a/themes/typemill/partials/navigation.twig
+++ b/themes/typemill/partials/navigation.twig
@@ -14,10 +14,12 @@
 			<li class="{{ element.elementType }} level-{{ depth }}">
 		{% endif %}
             {% if (element.elementType == 'folder') %}
-				<a href="{{ element.urlAbs }}">{% if chapnum %}{{ element.chapter }}. {% endif %}{{ element.name }}</a>		
+				<a href="{{ element.urlAbs }}">{% if chapnum %}{{ element.chapter }}. {% endif %}{{ element.name }}</a>
+		{% if (element.folderContent|length > 0) %}	
                 <ul>
                     {{ macros.loop_over(element.folderContent,chapnum) }}
                 </ul>
+		{% endif %}
             {% else %}
 				<a href="{{ element.urlAbs }}">{% if chapnum %}{{ element.chapter }} {% endif %}{{ element.name }}</a>
             {% endif %}


### PR DESCRIPTION
This prevents empty <ul></ul>tags for folders without content.