### PR TITLE
French translation update

### DIFF
--- a/system/author/languages/fr.yaml
+++ b/system/author/languages/fr.yaml
@@ -3,27 +3,30 @@ ACCOUNT: Compte
 ACTIVE: Actif
 ACTUAL_PASSWORD: Mot de passe actuel
 ADD: Ajouter
-ADD CONTENT-BLOCK: ajouter un bloc
-ADD DEFINITION: ajouter une définition
+ADD_CONTENT_BLOCK: ajouter un bloc
+ADD_DEFINITION: ajouter une définition
 ADD_FILE: Ajouter un article
 ADD_FOLDER: Ajouter un dossier
 ADD_FOLDER_TO_BASE_LEVEL: Ajouter un dossier de premier niveau
 ADD_ITEM: Ajouter un élément
-ADD LEFT COLUMN: Ajouter une colonne à gauche
-ADD RIGHT COLUMN: Ajouter une colonne à droite
-ADD ROW ABOVE: Ajouter une rangée en haut
-ADD ROW BELOW: Ajouter une rangée en bas
+ADD_LEFT_COLUMN: Ajouter une colonne à gauche
+ADD_RIGHT_COLUMN: Ajouter une colonne à droite
+ADD_ROW_ABOVE: Ajouter une rangée en haut
+ADD_ROW_BELOW: Ajouter une rangée en bas
 ALL_USERS: Tous les utilisateurs
 ALT_TEXT: Texte alternatif
+ALTERNATIVE_TEXT_FOR_THE_HERO_IMAGE: Texte alternatif pour la bannière d'accueil
 AUTHOR: Auteur
+AUTHOR_DESCRIPTION__MARKDOWN_: Description (Markdown)
 BACK_TO_STARTPAGE: Revenir à la page d'accueil
 BOLD: Gras
 BOTTOM: En bas
-BROWSE: Feuilleter
+BROWSE: Parcourir
 BULLET_LIST: Liste à puces
 BY: de
 CANCEL: Annuler
 CAPTION: Légende
+CAN_BE_USED_FOR_AUTHOR_LINE_IN_FRONTEND_: Sera affiché comme auteur sur le site web.
 CELL: Cellule
 CENTER: Center
 CHECK: Vérifier
@@ -73,9 +76,11 @@ FORMAT: Mise en forme
 GENERAL_PRESENTATION: Presentation générale
 GERMAN: Allemand
 GOOGLE_SITEMAP: Google Sitemap
+HAS_EDIT_RIGHTS_FOR_THIS_ARTICLE_: Possède les droits d'édition sur cette article.
 HEAD: Tête de colonne
 HEADLINE_ANCHORS: Ancres de titre
 HEADLINE: Titre
+HERO_IMAGE: Bannière d'accueil (Hero image)
 HIDE: Masquer
 HIDE_PAGE_FROM_NAVIGATION: Masquer dans le menu de navigation du site
 HOME: Accueil
@@ -84,6 +89,8 @@ HORIZONTAL_LINE: Ligne horizontale
 HR: Ligne horizontale
 IF_NOT_FILLED__THE_DESCRIPTION_IS_EXTRACTED_FROM_CONTENT_: Si non renseignée ici, la description est extraite du contenu.
 IMAGE: Image
+IMAGE_URL: URL de l'image
+IMAGE_URL__READ_ONLY_: URL de l'image (lecture seule)
 IMAGES: Images
 ITALIAN: Italien
 ITALIC: Italique
@@ -101,6 +108,7 @@ LOGO: Logo
 LOGOUT: Déconnexion
 MANUAL_DATE: Date manuelle
 MARKDOWN: Markdown
+MAXIMUM_SIZE_FOR_AN_IMAGE_IS_5_MB__HERO_IMAGES_ARE_NOT_SUPPORTED_BY_ALL_THEMES_: La taille maximale pour une image est 5 Mo. Les bannières d'accueil ne sont pas gérées dans tous les thèmes.
 MENU: Menu
 META_DESCRIPTION: Meta description
 META: Métadonnées
@@ -115,9 +123,11 @@ NO_PREVIEW: Pas de prévisualisation
 NO_SETTINGS: Aucun paramètre
 NOT_EDITABLE: Non modifiable
 NUMBERED_LIST: Liste numérotée
+NOTICE: Note
 OLIST: Liste ordonnée
 ONLINE: Online
 ONLY_THE_FOLLOWING_SPECIAL_CHARACTERS_ARE_ALLOWED: Seuls sont autorisés les caractères spéciaux suivants :
+OWNER__USERNAME_: Responsable de l'article (nom)
 PARAGRAPH: Paragraphe
 PASSWORD: Mot de passe
 PLEASE_CONFIRM: Confirmer
@@ -125,6 +135,7 @@ PLEASE_CORRECT_THE_ERRORS_ABOVE: Veuillez corriger les erreurs ci-dessus
 PLUGINS: Plugins
 PLUGIN_STORE: Dépôt des plugins
 POWER_OFF: Éteindre
+PROFILE_IMAGE: Image du Profil
 PUBLISH: Publier
 QUOTE: Citation
 QUOTES: Citations
@@ -143,7 +154,7 @@ SAVED_SUCCESSFULLY: Enregistré avec succès
 SAVE: Enregistrer
 SAVE_THEME: Enregistrer et activer ce thème
 SELECT_FROM_MEDIALIB: Sélectionner dans la bibliothèque de médias
-SETTINGS_ARE_STORED: les paramètres sont mis en mémoire
+SETTINGS_ARE_STORED: Les paramètres sont mis en mémoire
 SETTINGS: Paramètres
 SETUP: Configuration
 SHOW_ANCHORS_NEXT_TO_HEADLINES: Afficher les ancres à coté des titres
@@ -153,8 +164,8 @@ SYSTEM: Système
 TABLE_OF_CONTENTS: Sommaire
 TABLE: Tableau
 TAKEN_FROM_YOUR_USER_ACCOUNT_IF_SET_: Si non renseigné ici, le nom est tiré du compte utilisateur courant.
-TERM: terme
-TEXT_FILE: fichier texte
+TERM: Terme
+TEXT_FILE: Fichier texte
 THE_FORMAT_BUTTONS: Boutons de mise en forme
 THEMES: Thèmes
 THEME_STORE: Dépôt des thèmes
@@ -167,12 +178,14 @@ UNKNOWN: Inconnu
 UPDATE_USER: Mettre à jour l'utilisateur
 UPLOAD: Télécharger
 UPLOAD_FILE: Télécharger un fichier
+UPLOAD_AN_IMAGE: Télécharger une image
 USE_2_TO_20_CHARACTERS: Vous devez saisir au moins 2 caractères et au maximum 20.
 USE_2_TO_40_CHARACTERS: Vous devez saisir au moins 2 caractères et au maximum 40.
 USE_A_VALID_LANGUAGE_ATTRIBUTE: Veuillez indiquer un attribut de langue valide
 USE_A_VALID_YEAR: Entrez une année valide
-USED_AS_FALLBACK_WHEN_NO_MANUAL_DATE_IS_SET_: Utilisé si aucune date manuelle n'est définie.
+USED_AS_FALLBACK_WHEN_NO_MANUAL_DATE_IS_SET_: Utilisée si aucune date manuelle n'est définie.
 USERNAME: Nom de l'utilisateur
+USERNAME__READ_ONLY_: Nom de l'utilisateur (lecture seule)
 USER: Utilisateur
 USERS: Utilisateurs
 VIDEO: Vidéo
@@ -185,6 +198,7 @@ VISUAL: Visuel
 WAIT: Attendez
 WEB: Site
 WEBSITE_TITLE: Titre du site
+WEBSITE_VISIBLE_FOR: Site visible pour
 WRITING: Rédaction
 YEAR: Année
 YOU_CAN_OVERWRITE_THE_THEME_CSS_WITH_YOUR_OWN_CSS_HERE_: Vous pouvez surcharger ici le css du thème avec vos propres styles.
@@ -193,14 +207,14 @@ SETUP_WELCOME: Bienvenue dans l'installation
 HURRA: Hourrah
 YOUR_ACCOUNT_HAS_BEEN_CREATED_AND_YOU_ARE_LOGGED_IN_NOW_: Votre compte a été créé et vous êtes maintenant connecté
 NEXT_STEP: Prochaine étape:
-VISIT_THE_AUTHOR_PANEL_AND_SETUP_YOUR_NEW_WEBSITE__YOU_CAN_CONFIGURE_THE_SYSTEM__CHOOSE_THEMES_AND_ADD_PLUGINS_: Visitez le volet Auteur et configurez votre nouveau site. Vous pouvez paramétrer le système, choisir un thème et ajouter des plugins.
+VISIT_THE_AUTHOR_PANEL_AND_SETUP_YOUR_NEW_WEBSITE__YOU_CAN_CONFIGURE_THE_SYSTEM__CHOOSE_THEMES_AND_ADD_PLUGINS_: Visitez le compte Utilisateur et configurez votre nouveau site. Vous pouvez paramétrer le système, choisir un thème et ajouter des plugins.
 GET_HELP: Obtenir de l'aide:
 IF_YOU_HAVE_ANY_QUESTIONS__PLEASE_READ_THE: Pour toutes questions, veuillez consulter la
 DOCS: documentation
 OR_OPEN_A_NEW_ISSUE_ON: ou ouvrir un nouveau bug sur
 CODED_WITH: Codé avec
-BY_THE: par
-COMMUNITY: communauté
+BY_THE: par la
+COMMUNITY: Communauté
 TRENDSCHAU_DIGITAL: Trendschau Digital
 CONFIGURE_YOUR_WEBSITE: Configurez votre site
 GIVE_YOUR_NEW_WEBSITE_A_NAME__ADD_THE_AUTHOR_AND_CHOOSE_A_COPYRIGHT_: Donnez un nom à votre nouveau site, ajouter un auteur et choisissez un copyright.

--- a/themes/cyanine/languages/admin/fr.yaml
+++ b/themes/cyanine/languages/admin/fr.yaml
@@ -1,0 +1,84 @@
+# Français
+# Ajoutez les traductions dans votre thème comme ici
+ACTIVATE_A_LANDINGPAGE: Activer une landing page
+ACTIVATE_FOOTER_COLUMNS: Activer les colonnes du pied de page
+ADD_A_PATH_TO_A_FOLDER_FROM_WHICH_YOU_WANT_TO_LIST_ENTRIES: Ajouter un chemin d'accès à un dossier à partir duquel vous souhaitez lister les entrées
+ADD_THE_BASE_URL_TO_THE_CONTENT_REPOSITORY__E_G__GITHUB__: Ajouter l'url de base vers un dépôt de contenu (par exemple Github).
+ALL_FONTS_ARE_SYSTEM_FONTS_WITH_(FALLBACKS)_IF_THE_FONT_IS_NOT_INSTALLED: Toutes les polices sont des polices système (avec solution de recours si la police n'est pas installée)
+ARTICLE_AUTHOR: Auteur de l'article
+ARTICLE_DATE: Date de création
+ARTICLE_EDIT_LINK: Lien d'édition de l'article
+AUTHOR_INTRO_TEXT: Texte d'introduction de l'auteur
+BASIC_FONT_FAMILY: Police de base
+BOTTOM: Bas 
+BUTTON_LABEL: Étiquette de bouton
+BUTTON_LINK: Bouton lien
+COLLAPSE_NAVIGATION: Réduire les menus
+COLLAPSE_AND_EXPAND_NAVIGATION?: Replier et développer les menus ?
+COLORS: Couleurs
+COLUMN_1: Colonne 1
+COLUMN_2: Colonne 2
+COLUMN_3: Colonne 3
+COUNT_CHAPTERS_IN_NAVIGATION?: Numéroter les chapitres dans le menu de navigation ?
+CYANINE_IS_A_MODERN_AND_FLEXIBLE_MULTI_PURPOSE_THEME_AND_THE_STANDARD_THEME_FOR_TYPEMILL_: Cyanine est un thème multi-usages moderne et adaptable. C'est le thème standard de Typemill.
+DATE_FORMAT: Format de la date de création/modifcation
+DATE_INTRO_TEXT: Étiquette de la date
+FONT_FAMILIES: Polices
+FONT_FAMILY_FOR_HEADLINES: Police pour les titres
+FONT_FAMILY_FOR_NAVIGATIONS: Police pour les menus
+FOOTER_COLUMN_1_(USE_MARKDOWN): Pied de page colonne 1 (utilisez le markdown)
+FOOTER_COLUMN_2_(USE_MARKDOWN): Pied de page colonne 2 (utilisez le markdown)
+FOOTER_COLUMN_3_(USE_MARKDOWN): Pied de page colonne 3 (utilisez le markdown)
+FOOTER_COLUMNS: Colonnes de pied de page
+HEADLINE_FOR_NEWS_SEGMENT: Titres pour les segments Actualités 
+HOW_MANY_NAVIGATION_LEVELS?: Combien de niveaux de menu ?
+LABEL_FOR_READ_MORE_LINK: Étiquette pour les liens Plus
+LABEL_FOR_STARTBUTTON: Étiquette pour le bouton de démarrage
+LANDINGPAGE_CONTRAST_SEGMENT: Segment Contraste de la landing page
+LANDINGPAGE_INFO_SEGMENT: Segment Info de la landing page
+LANDINGPAGE_INTRO_SEGMENT: Segment Intro de la landing page
+LANDINGPAGE_NAVIGATION_SEGMENT: Segment Menu de la landing page
+LANDINGPAGE_NEWS_SEGMENT: Segment Actualités de la landing page
+LANDINGPAGE_TEASER_SEGMENT: Segment Teaser de la landing page
+LINK_FOR_STARTBUTTON: Lien pour le bouton de démarrage
+LINK_TO_REPOSITORY: Lien vers le dépôt Git
+LIST_ENTRIES_FROM_FOLDER: Lister les entrées à partir du dossier
+NAVIGATIONS_AND_CHAPTERS: Menus et chapitres
+POSITION_OF_ARTICLE_AUTHOR_LINE_(TOP/BOTTOM): Position de la ligne Auteur (haut/bas)
+POSITION_OF_ARTICLE_DATE_(TOP/BOTTOM): Position de la date de création/modification de l'article (haut/bas)
+POSITION_OF_CONTRAST_SEGMENT: Position du segment Contraste
+POSITION_OF_INFO_SEGMENT: Position du segment Info
+POSITION_OF_INTRO_SEGMENT: Position du segment Intro
+POSITION_OF_NAVI_SEGMENT: Position du segment Menu
+POSITION_OF_NEWS_SEGMENT: Position du segment Actualités
+POSITION_OF_TEASER_SEGMENT: Position du segment Teaser
+POSITION_OF_THE_EDIT_LINK_(TOP/BOTTOM): Position du lien d'édition (haut/bas)
+PRIMARY_BRAND_COLOR: Couleur principale
+PRIMARY_FONT_COLOR: Couleur principale de police
+SECONDARY_BRAND_COLOR: Couleur secondaire
+SECONDARY_FONT_COLOR: Couleu secondaire de police
+SHOW_CHAPTER_NUMBERS: Afficher les numéros de chapitre
+SHOW_CHAPTER_NUMBERS_IN_NAVIGATION?: Afficher les numéros de chapitre dans les menus ?
+TEASER_1_LABEL: Teaser 1 Label
+TEASER_1_LINK: Teaser 1 Lien
+TEASER_1_TEXT: Teaser 1 Texte
+TEASER_1_TITLE: Teaser 1 Titre
+TEASER_2_LABEL: Teaser 1 Label
+TEASER_2_LINK: Teaser 2 Lien
+TEASER_2_TEXT: Teaser 2 Texte
+TEASER_2_TITLE: Teaser 2 Titre
+TEXT/LABEL_FOR_EDIT_LINK: Texte/label pour le lien d'édition
+TEXT_LINKS: Liens textes
+TEXT: Texte
+THIN_BORDER_COLOR: Couleur des bordures fines
+TITLE_FOR_NAVIGATION: Titre pour le menu
+TITLE: Titre
+TOP: Haut
+USE_0_TO_DISABLE_THE_SECTION: Utilisez 0 pour désactiver la section
+USED_AS_CONTRARY_COLOR_FOR_HOVERS_IN_NAVIGATION_AND_BUTTONS: Utilisée comme couleur inverse au passage de la souris sur les menus et les boutons
+USED_FOR_CONTENT_BACKGROUND__FONT_COLORS_ON_HOVER_AND_MORE: Utilisée comme couleur d'arrière-plan, couleur de police au passage de la souris et autres
+USED_FOR_LINKS__CHECK_CONTRAST_FOR_A11Y_: Utilisée pour les liens, vérifiez le contraste pour a11y.
+USED_FOR_TEXT: Utilisée pour le texte
+USED_FOR_THE_BODY_BACKGROUND_AND_BORDERS: Utilisée pour l'arrière plan du body et pour les bordures
+USED_FOR_THIN_BORDERS_IN_NAVIGATIONS_AND_TABLES: Utilisée pour les bordures fines dans les menus et les tableaux
+USE_MARKDOWN: Utilisez le markdown


### PR DESCRIPTION
Hey Sebastian
Here is an update for french translation.

Doing it, I found some little defaults that are not bound to translation itself I guess :
1) at first successfull connexion screen, double colons are to be seen after *Next step* and *Get help* strings.
In french version that shows like this:
"**Prochaine étape**:: Visitez le compte Utilisateur et configurez votre nouveau site. Vous pouvez paramétrer le système, choisir un thème et ajouter des plugins.
**Obtenir de l'aide**:: Pour toutes questions, veuillez consulter la..." 

2) in Settings Tab, Account section
Among new strings, the PROFILE-IMAGE string can be translated while the following cannot:
USERNAME (READ ONLY)
IMAGE URL
AUTHOR-DESCRIPTION (MARKDOWN)

Olivier