### PR TITLE
"Ignore" feature for translations

### DIFF
--- a/system/author/languages/it.yaml
+++ b/system/author/languages/it.yaml
@@ -1,4 +1,4 @@
-# Italian (Italiano)
+# Italian (Italiano) pls ignore autoupdates
 # Author: Severo Iuliano (https://github.com/iusvar)
 ACCOUNT: Utenza
 ACTIVE: Attivo

--- a/system/author/languages/updater.py
+++ b/system/author/languages/updater.py
@@ -24,6 +24,8 @@ if __name__ == '__main__':
 	key = [t.split(': ', 1)[0] for t in data]
 	for i in lang_codes[1:]:  # all lang codes except en, because en used like template
 		any_header = f_open(i).split('\n')
+		if 'ignore' in any_header[0].lower():  # first string in file may contain ignore keyword
+			continue
 		any_data = any_header[2:]
 		any_header = any_header[:2]
 		any_key = [t.split(': ', 1)[0] for t in any_data]


### PR DESCRIPTION
Hehehe, I sorry for spending a week on 2 strings of code. I was kinda busy and apologize for the delay.

Now, if you add the word - **ignore** to the first string of the lang file, the script auto-updater will ignore this file.
_You already can see an example in it.yaml_