### PR TITLE
bugfix: #236 File-Upload changes files: only write content to file no…

### DIFF
--- a/system/Models/ProcessFile.php
+++ b/system/Models/ProcessFile.php
@@ -38,7 +38,7 @@ class ProcessFile extends ProcessAssets
 
 		$path = $this->tmpFolder . $this->getFullName();
 
-		if(file_put_contents($path, $file))
+		if($file !== false && file_put_contents($path, $file["file"]))
 		{
 			$size = filesize($path);
 			$size = $this->formatSizeUnits($size);


### PR DESCRIPTION
fixes #236 

decodeFile returns an array containing data and type, the return value was used with `file_puts_contents($path, $file)` which caused that the content type was written to the file too.