### PR TITLE
When scanning for themes make sure to only consider visible folders

### DIFF
--- a/system/Settings.php
+++ b/system/Settings.php
@@ -33,7 +33,9 @@ class Settings
 		if(!isset($settings['theme']) OR !file_exists($themefolder . $settings['theme']))
 		{
 			# scan theme folder and get the first theme
-			$themes = array_diff(scandir($themefolder), array('..', '.'));
+			$themes = array_filter(scandir($themefolder), function ($item) use($themefolder) {
+				return is_dir($themefolder . $item) && strpos($item, '.') !== 0;
+			});
 			$firsttheme = reset($themes);
 
 			# if there is a theme with an index.twig-file


### PR DESCRIPTION
Hi!
I just downloaded typemill and tried to test it out locally on my Mac; when copying the dev theme into the theme folder the installation suddenly stopped working with a slightly misleading error message:

> You need at least one theme with an index.twig-file in your theme-folder.

I still had two folders with an index.twig in the theme directory, but when using the Finder, macOS automatically creates a hidden `.DS_Store` which counts as the "first" file in the directory. Some users might not know this and will not have a clue how to recover their installation.

I have now changed the theme filtering to only (1) consider folders that (2) do not start with a dot.

As the theme loading part still only checks the first folder it encounters, maybe also consider either rewriting the error message to something like

> The first folder in the themes directory does not include an index.twig-file

or include a while loop to cycle through theme directories?

