### PR TITLE
Hide hidden folders like ".git" in the navigation

### DIFF
--- a/system/Models/Folder.php
+++ b/system/Models/Folder.php
@@ -48,7 +48,7 @@ class Folder
 
 		foreach ($folderItems as $key => $item)
 		{
-			if (!in_array($item, array(".","..")))
+			if (!in_array($item, array(".","..")) && substr($item, 0, 1) != '.')
 			{
 				if (is_dir($folderPath . DIRECTORY_SEPARATOR . $item))
 				{


### PR DESCRIPTION
I have a git repo only for the content folder, which leads to the content folder having a ".git" folder which is shown in the backend navigation. I think in general it would be good to hide such folders which names start with a ".".