### PR TITLE
Add OnPagetreeLoaded Event to the setFreshNavigation method

### DIFF
--- a/system/Controllers/ControllerAuthorMediaApi.php
+++ b/system/Controllers/ControllerAuthorMediaApi.php
@@ -466,9 +466,8 @@ class ControllerAuthorMediaApi extends ControllerAuthor
 			$this->params['markdown'] = '![' . $class . '-video](' . $imageUrl . ' "click to load video"){#' . $videoID. ' .' . $class . '}';
 
 			$request 	= $request->withParsedBody($this->params);
-			
 			$block = new ControllerAuthorBlockApi($this->c);
-			if($params['new'])
+			if($this->params['new'])
 			{
 				return $block->addBlock($request, $response, $args);
 			}

--- a/system/Controllers/ControllerShared.php
+++ b/system/Controllers/ControllerShared.php
@@ -7,6 +7,7 @@ use Typemill\Models\Folder;
 use Typemill\Models\WriteCache;
 use Typemill\Models\WriteYaml;
 use Typemill\Events\OnPageReady;
+use Typemill\Events\OnPagetreeLoaded;
 
 abstract class ControllerShared
 {
@@ -226,7 +227,7 @@ abstract class ControllerShared
 				$this->setStructureLive();
 			}
 
-			$structureLive = $this->structureLive;
+			$structureLive = $this->c->dispatcher->dispatch('onPagetreeLoaded', new OnPagetreeLoaded($this->structureLive))->getData();
 			$this->navigation = $this->createNavigation($structureLive);
 
 			# cache navigation

--- a/system/Models/ProcessAssets.php
+++ b/system/Models/ProcessAssets.php
@@ -105,8 +105,7 @@ class ProcessAssets
 	public function setFileName($originalname, $type, $overwrite = NULL)
 	{
 		$pathinfo			= pathinfo($originalname);
-		
-		$this->extension 	= strtolower($pathinfo['extension']);
+		$this->extension 	= isset($pathinfo['extension']) ? strtolower($pathinfo['extension']) : null;
 		$this->filename 	= Folder::createSlug($pathinfo['filename']);
 
 		$filename = $this->filename;


### PR DESCRIPTION
If you manipulate the navigation within a plugin these plugin events should also be called when the cache for the navigation gets created.