### PR TITLE
Fix problems with Docker under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Docker under Windows need LF (\n) EOL in scripts
+/docker-utils/** text eol=lf


### PR DESCRIPTION
Docker under Windows need LF (\n) EOL in scripts