### PR TITLE
Improved password reset reliability

### DIFF
--- a/system/Controllers/ControllerFrontendAuth.php
+++ b/system/Controllers/ControllerFrontendAuth.php
@@ -147,7 +147,7 @@ class ControllerFrontendAuth extends ControllerShared
 			return $response->withRedirect($this->c->router->pathFor('auth.recoverpwshow'));			
 		}
 
-		$requiredUser = $user->getSecureUser($requiredUser[0]);
+		$requiredUser = $user->getSecureUser($requiredUser['username']);
 		
 		$requiredUser['recoverdate'] 	= date("Y-m-d H:i:s");
 		$requiredUser['recovertoken'] 	= bin2hex(random_bytes(32));


### PR DESCRIPTION
Without this change, it might fail to load the user, as accessing the associative array by the integer index would return null instead of the username element value.