### PR TITLE
Add support for scheme-less base_url

### DIFF
--- a/cypress/fixtures/01_setup/prepulate_settings_seed/settings/settings.yaml
+++ b/cypress/fixtures/01_setup/prepulate_settings_seed/settings/settings.yaml
@@ -34,6 +34,7 @@ twigcache: null
 proxy: null
 trustedproxies: ""
 headersoff: null
+schemelessbaseurl: null
 urlschemes: ""
 svg: null
 recoverpw: null

--- a/system/Controllers/ControllerSettings.php
+++ b/system/Controllers/ControllerSettings.php
@@ -111,6 +111,7 @@ class ControllerSettings extends ControllerShared
 					'proxy'					=> isset($newSettings['proxy']) ? true : null,
 					'trustedproxies'		=> $newSettings['trustedproxies'],
 					'headersoff'			=> isset($newSettings['headersoff']) ? true : null,
+					'schemelessbaseurl'		=> isset($newSettings['schemelessbaseurl']) ? true : null,
 					'urlschemes'			=> $newSettings['urlschemes'],
 					'svg'					=> isset($newSettings['svg']) ? true : null,
 					'recoverpw'				=> isset($newSettings['recoverpw']) ? true : null,

--- a/system/Middleware/assetMiddleware.php
+++ b/system/Middleware/assetMiddleware.php
@@ -8,33 +8,40 @@ use Slim\Http\Response;
 
 class assetMiddleware
 {
-    protected $view;
-    protected $c;
-    
-    public function __construct($container)
-    {
-        # $this->view = $view;
-        $this->container = $container;
-    }
-    
-    public function __invoke(Request $request, Response $response, $next)
-    {
+	protected $view;
+	protected $c;
+	protected $settings;
+	
+	public function __construct($container, $settings)
+	{
+		# $this->view = $view;
+		$this->container = $container;
+		$this->settings 	= $settings;
+	}
+	
+	public function __invoke(Request $request, Response $response, $next)
+	{
 
-    	# get the uri after proxy detection
-        $uri 	= $request->getUri()->withUserInfo('');
+		# get the uri after proxy detection
+		$uri 	= $request->getUri()->withUserInfo('');
+
+		if(isset($this->settings['schemelessbaseurl']) && $this->settings['schemelessbaseurl'])
+		{
+			$uri = $uri->withScheme('');
+		}
 
 		# update the asset object in the container (for plugins) with the new url
 		$this->container->assets->setBaseUrl($uri->getBaseUrl());
 
-        # add the asset object to twig-frontend for themes
-        $this->container['view']->getEnvironment()->addGlobal('assets', $this->container['assets']);
-        
-        # use {{ base_url() }} in twig templates
+		# add the asset object to twig-frontend for themes
+		$this->container['view']->getEnvironment()->addGlobal('assets', $this->container['assets']);
+		
+		# use {{ base_url() }} in twig templates
 		$this->container['view']['base_url']	 	= $uri->getBaseUrl();
 		$this->container['view']['current_url'] 	= $uri->getPath();
 
-	    $response = $next($request, $response);
-	    
-	    return $response;
-    }
+		$response = $next($request, $response);
+		
+		return $response;
+	}
 }

--- a/system/Settings.php
+++ b/system/Settings.php
@@ -185,6 +185,7 @@ class Settings
 									'proxy' => true,
 									'trustedproxies' => true,
 									'headersoff' => true,
+									'schemelessbaseurl' => true,
 									'urlschemes' => true,
 									'svg' => true,
 									'recoverpw' => true,

--- a/system/author/languages/de.yaml
+++ b/system/author/languages/de.yaml
@@ -181,6 +181,8 @@ SAVE: speichern
 SAVE_ALL_SETTINGS: Alle Einstellungen speichern
 SAVE_THEME: Theme speichern
 SAVED_SUCCESSFULLY: Erfolgreich gespeichert
+SCHEMELESS_BASE_URL: Schemalose Basis-URL
+SCHEMELESS_BASE_URL_DESC: Entfernt das Schema (d.h., HTTP oder HTTPS) beim Adressieren von Ressourcen
 SECURITY_LOG: Security Log
 SELECT_FROM_MEDIALIB: Aus Medialib wählen
 SELECT_THE_LOWEST_USERROLE__HIGHER_ROLES_WILL_HAVE_ACCESS_TOO_: Wähle die niedrigste Nutzerrolle. Höhere Nutzerrollen haben ebenfalls Zugriff.

--- a/system/author/languages/en.yaml
+++ b/system/author/languages/en.yaml
@@ -181,6 +181,8 @@ SAVE: Save
 SAVE_ALL_SETTINGS: Save All Settings
 SAVE_THEME: Save Theme
 SAVED_SUCCESSFULLY: Saved successfully
+SCHEMELESS_BASE_URL: Schemeless Base Url
+SCHEMELESS_BASE_URL_DESC: Remove scheme (i.e., HTTP or HTTPS) when addressing resources
 SECURITY_LOG: Security Log
 SELECT_FROM_MEDIALIB: select from medialib
 SELECT_THE_LOWEST_USERROLE__HIGHER_ROLES_WILL_HAVE_ACCESS_TOO_: Select the lowest userrole. Higher roles will have access too.

--- a/system/author/languages/fr.yaml
+++ b/system/author/languages/fr.yaml
@@ -181,6 +181,8 @@ SAVE: Enregistrer
 SAVE_ALL_SETTINGS: Sauvegarder tous les paramètres
 SAVE_THEME: Enregistrer et activer ce thème
 SAVED_SUCCESSFULLY: Enregistré avec succès
+SCHEMELESS_BASE_URL: URL de base sans schéma
+SCHEMELESS_BASE_URL_DESC: Supprime le schéma (c.-à-d., HTTP ou HTTPS) lors de l'adressage des ressources
 SECURITY_LOG: Security Log
 SELECT_FROM_MEDIALIB: Sélectionner dans la bibliothèque de médias
 SELECT_THE_LOWEST_USERROLE__HIGHER_ROLES_WILL_HAVE_ACCESS_TOO_: Selectionner le rôle minimal. Les rôles plus élevés accèderont également.

--- a/system/author/languages/it.yaml
+++ b/system/author/languages/it.yaml
@@ -161,6 +161,8 @@ SAVE: Salva
 SAVED_SUCCESSFULLY: Salvato con successo
 SAVE_ALL_SETTINGS: Salva tutte le impostazioni
 SAVE_THEME: Salva tema
+SCHEMELESS_BASE_URL: URL di base senza schema
+SCHEMELESS_BASE_URL_DESC: Rimuove lo schema (cioè, HTTP o HTTPS) durante l'indirizzamento delle risorse
 SELECT_FROM_MEDIALIB: seleziona da medialib
 SETTINGS: Impostazioni
 SETTINGS_ARE_STORED: Le impostazioni sono memorizzate

--- a/system/author/languages/nl.yaml
+++ b/system/author/languages/nl.yaml
@@ -181,6 +181,8 @@ SAVE: Opslaan
 SAVE_ALL_SETTINGS: Sla alle instellingen op
 SAVE_THEME: Thema opslaan
 SAVED_SUCCESSFULLY: Succesvol opgeslagen
+SCHEMELESS_BASE_URL: URL zonder schema
+SCHEMELESS_BASE_URL_DESC: Verwijdert het schema (d.w.z., HTTP of HTTPS) bij het adresseren van bronnen
 SECURITY_LOG: Security Log
 SELECT_FROM_MEDIALIB: Selecteer uit medialib 
 SELECT_THE_LOWEST_USERROLE__HIGHER_ROLES_WILL_HAVE_ACCESS_TOO_: Selecteer de laagste gebruikersrol. Hogere rollen hebben ook toegang. 

--- a/system/author/languages/ru.yaml
+++ b/system/author/languages/ru.yaml
@@ -181,6 +181,8 @@ SAVE: Сохранить
 SAVE_ALL_SETTINGS: Сохранить все настройки
 SAVE_THEME: Сохранить настройки Темы
 SAVED_SUCCESSFULLY: Успешно сохранено
+SCHEMELESS_BASE_URL: Базовый URL без схемы
+SCHEMELESS_BASE_URL_DESC: Удаляет схему (т.е., HTTP или HTTPS) при адресации ресурсов
 SECURITY_LOG: Логи безопасности
 SELECT_FROM_MEDIALIB: Выбрать из библиотеки
 SELECT_THE_LOWEST_USERROLE__HIGHER_ROLES_WILL_HAVE_ACCESS_TOO_: Выберите роль пользователя. Более важные роли также будут иметь доступ к странице.

--- a/system/author/settings/system.twig
+++ b/system/author/settings/system.twig
@@ -322,6 +322,13 @@
 							<span class="checkmark"></span>
 						</label>
 					</div>
+					<div class="large{{ errors.settings.schemelessbaseurl ? ' error' : '' }}">
+						<label for="settings[schemelessbaseurl]">{{ __('Schemeless Base Url') }}</label>
+						<label class="control-group">{{ __('Remove scheme (i.e., HTTP or HTTPS) when addressing resources') }}
+							<input name="settings[schemelessbaseurl]" type="checkbox" {% if (settings.schemelessbaseurl or old.settings.schemelessbaseurl) %} checked {% endif %}>
+							<span class="checkmark"></span>
+						</label>
+					</div>
 				</fieldset>
 			</section>
 			<input type="submit" value="{{ __('Save All Settings') }}" />

--- a/system/system.php
+++ b/system/system.php
@@ -309,7 +309,7 @@ if($container['flash'])
 *  ASSET MIDDLEWARE FOR TWIG	*
 ********************************/
 
-$app->add(new \Typemill\Middleware\assetMiddleware($container));
+$app->add(new \Typemill\Middleware\assetMiddleware($container, $container['settings']));
 
 /********************************
 *  PROXY DETECTION FOR REQUEST	*


### PR DESCRIPTION
I'm utilizing a proxy that internally accesses Typemill using HTTP and externally exposes the site using HTTPS. However, Typemill mistakenly perceives the request as coming from 'http://example.com/' instead of the actual 'https://example.com/.' As a result, loading other resources like JavaScript, CSS, and XHR requests may trigger the mixed-content policy of browsers, leading to the blocking of these resources.

To address this issue, I have introduced an option to remove the scheme from the base_url which allows browsers to load resources without triggering the mixed-content policy. This option can be beneficial for others experiencing similar challenges with the mixed-content policy.